### PR TITLE
Update Comments.tmPreferences

### DIFF
--- a/syntax/Comments.tmPreferences
+++ b/syntax/Comments.tmPreferences
@@ -5,7 +5,7 @@
 	<key>name</key>
 	<string>Comments</string>
 	<key>scope</key>
-	<string>text.pddl</string>
+	<string>source.pddl</string>
 	<key>settings</key>
 	<dict>
 		<key>shellVariables</key>


### PR DESCRIPTION
The sublime comment block functionality is currently not working properly. Changing "text.pddl" to "source.pddl" fixed the problem for me on sublime text 3 build 3114 on Ubuntu 16.04
